### PR TITLE
Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "mongoose": "^6.2.7",
     "mongoose-paginate-v2": "^1.6.3",
     "morgan": "^1.10.0",
-    "prettier": "^2.6.0",
     "yup": "^0.32.11"
   },
   "devDependencies": {
     "jest": "^27.5.1",
     "nodemon": "^2.0.15",
+    "prettier": "^2.6.0",
     "supertest": "^6.2.2",
     "weak-napi": "^2.0.2"
   }


### PR DESCRIPTION
O pacote [prettier](https://www.npmjs.com/prettier) deve estar como dependência de desenvolvimento